### PR TITLE
Propagate fieldgroup weights to template wrappers.

### DIFF
--- a/template.php
+++ b/template.php
@@ -921,6 +921,7 @@ function ddbasic_preprocess_ting_object(&$vars) {
               'left_column' => $content['group_ting_object_left_column'],
               'right_column' => $content['group_ting_object_right_column'],
             ),
+            '#weight' => $content['group_ting_object_left_column']['#weight'],
           );
 
           unset($content['group_ting_object_left_column']);
@@ -936,6 +937,7 @@ function ddbasic_preprocess_ting_object(&$vars) {
               '#suffix' => '</div>',
               'details' => $content['group_material_details'],
             ),
+            '#weight' => $content['group_material_details']['#weight'],
           );
           unset($content['group_material_details']);
         }
@@ -949,6 +951,7 @@ function ddbasic_preprocess_ting_object(&$vars) {
               '#suffix' => '</div>',
               'details' => $content['group_holdings_available'],
             ),
+            '#weight' => $content['group_holdings_available']['#weight'],
           );
           unset($content['group_holdings_available']);
         }
@@ -962,6 +965,7 @@ function ddbasic_preprocess_ting_object(&$vars) {
               '#suffix' => '</div>',
               'details' => $content['group_periodical_issues'],
             ),
+            '#weight' => $content['group_periodical_issues']['#weight'],
           );
           unset($content['group_periodical_issues']);
         }
@@ -975,6 +979,7 @@ function ddbasic_preprocess_ting_object(&$vars) {
               '#suffix' => '</div>',
               'details' => $content['group_on_this_site'],
             ),
+            '#weight' => $content['group_on_this_site']['#weight'],
           );
           unset($content['group_on_this_site']);
         }
@@ -984,6 +989,7 @@ function ddbasic_preprocess_ting_object(&$vars) {
             'content' => array(
               'details' => $content['ting_relations'],
             ),
+            '#weight' => $content['ting_relations']['#weight'],
           );
           unset($content['ting_relations']);
         }


### PR DESCRIPTION
When moving the fieldgroups into wrappers in ddbasic_preprocess_ting_object(), the #weights gets lost. The upshoot of this is that if any field is added outside a fieldgroup, or any other child with a #weight gets added, the order of the groups will be jumbled.

The underlying reason is that element_children will preserve the order of children if none have a weight set, but if any have a weight, uasort() will be used, which doesn't make any guarantees on the order of items which is considered equal, and all the group wrappers will get a default #weight of zero.

Copying the group weight not only fixes this, but allows one to make minor ordering adjustments in the backend again.
