### PR TITLE
Issue 510: Fix group layout if it contains one content type.

### DIFF
--- a/sass/module/_groups.scss
+++ b/sass/module/_groups.scss
@@ -205,19 +205,19 @@
   border-top: 1px solid $gray-light;
   padding-top: $large-spacing;
 
+  // News and events are normally presented in a two column layout when
+  // displaying a group. If the group only contains a single kind of content
+  // then display that content in full width.
+  // See ddbasic.common.js for detection.
+  &.js-og-single-content-type {
+    @include zen-clear(both);
+    @include zen-grid-item(12, 1);
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   @include small-medium() {
     @include zen-clear(both);
     @include zen-grid-item(12, 1);
   }
-}
-
-// News and events are normally presented in a two column layout when
-// displaying a group. If the group only contains a single kind of content
-// then display that content in full width.
-// See ddbasic.common.js for detection.
-.js-ding-group-single-content-type {
-  @include zen-clear(both);
-  @include zen-grid-item(12, 1);
-  padding-left: 0;
-  padding-right: 0;
 }

--- a/sass/module/_groups.scss
+++ b/sass/module/_groups.scss
@@ -210,3 +210,14 @@
     @include zen-grid-item(12, 1);
   }
 }
+
+// News and events are normally presented in a two column layout when
+// displaying a group. If the group only contains a single kind of content
+// then display that content in full width.
+// See ddbasic.common.js for detection.
+.js-ding-group-single-content-type {
+  @include zen-clear(both);
+  @include zen-grid-item(12, 1);
+  padding-left: 0;
+  padding-right: 0;
+}

--- a/sass/module/_libraries.scss
+++ b/sass/module/_libraries.scss
@@ -283,9 +283,22 @@
     border-top: 1px solid $gray-light;
     padding-top: $large-spacing;
 
+    // News and events are normally presented in a two column layout when
+    // displaying a group. If the group only contains a single kind of content
+    // then display that content in full width.
+    // See ddbasic.common.js for detection.
+    &.js-og-single-content-type {
+      @include zen-clear(both);
+      @include zen-grid-item(12, 1);
+      padding-left: 0;
+      padding-right: 0;
+    }
+
     @include small-medium() {
       @include zen-clear(both);
       @include zen-grid-item(12, 1);
     }
   }
+
 }
+

--- a/scripts/ddbasic.common.js
+++ b/scripts/ddbasic.common.js
@@ -68,12 +68,19 @@
       $(this).toggleClass('js-toggled');
     });
 
-    // Check group content. If a group does not contain both news and events
+    // Check an organic group and library content.
+    // If a group does not contain both news and events
     // then add an additional class to the content lists.
-    $('.ding-group-news,.ding-group-events').each(function() {
-      if ($(this).parent().find('.ding-group-news,.ding-group-events').size() < 2) {
-        $(this).addClass('js-ding-group-single-content-type');
-      }
+    [
+      '.ding-group-news,.ding-group-events',
+      '.ding-library-news,.ding-library-events'
+    ].forEach(function(e) {
+        var selector = e;
+        $(selector).each(function() {
+          if ($(this).parent().find(selector).size() < 2) {
+            $(this).addClass('js-og-single-content-type');
+          }
+      });
     });
   });
 

--- a/scripts/ddbasic.common.js
+++ b/scripts/ddbasic.common.js
@@ -67,6 +67,14 @@
       $('.menu', element).toggle();
       $(this).toggleClass('js-toggled');
     });
+
+    // Check group content. If a group does not contain both news and events
+    // then add an additional class to the content lists.
+    $('.ding-group-news,.ding-group-events').each(function() {
+      if ($(this).parent().find('.ding-group-news,.ding-group-events').size() < 2) {
+        $(this).addClass('js-ding-group-single-content-type');
+      }
+    });
   });
 
 })(jQuery);


### PR DESCRIPTION
Make that column appear in full width instead of half width with an empty column next to it.

Detection is handled by javascript as doing this through CSS or Panels is tricky/impossible.

Issue: http://platform.dandigbib.org/issues/510

Note that output has _not_ been compiled. For some reason CodeKit fails to find Zen Grids when using a branch.
