### PR TITLE
Feature/1267 focus on login field

### DIFF
--- a/scripts/ddbasic.login.js
+++ b/scripts/ddbasic.login.js
@@ -9,5 +9,18 @@
         $('.topbar-link-user').bind('click', function(event) {
             $('#user-login-form #edit-name').focus();
         });
+
+        // Unfocus login form when user wants to scroll with key buttons (i.e. clicks the up or down button).
+        $('#user-login-form').bind('keydown', function(event) {
+            var keymap = {
+                up: 38,
+                down: 40
+            };
+
+            // Only unfocus if we press the up or down key.
+            if (keymap.up == event.which || keymap.down == event.which) {
+                document.activeElement.blur();
+            }
+        });
     });
 }(jQuery));

--- a/scripts/ddbasic.login.js
+++ b/scripts/ddbasic.login.js
@@ -1,0 +1,13 @@
+(function($) {
+    "use strict";
+
+    $(document).ready(function() {
+        // Focus on username form field when entering login form.
+        $('#user-login-form #edit-name').focus();
+
+        // Focus on username form field when clicking login tab.
+        $('.topbar-link-user').bind('click', function(event) {
+            $('#user-login-form #edit-name').focus();
+        });
+    });
+}(jQuery));

--- a/template.php
+++ b/template.php
@@ -122,6 +122,10 @@ function ddbasic_form_alter(&$form, &$form_state, $form_id) {
       $form['pass']['#field_prefix'] = '<i class="icon-lock"></i>';
       $form['pass']['#attributes']['placeholder'] = t('Pincode is 4 digits');
 
+      // Add JavaScript that will place focus in the login box, when the Login
+      // is clicked.
+      drupal_add_js(drupal_get_path('theme', 'ddbasic') . '/scripts/ddbasic.login.js', 'file');
+
       unset($form['links']);
 
       // Temporary hack to get rid of open id links.


### PR DESCRIPTION
When user visits the login directly or clicks the login tab, the username field is set to focused.
When the user clicks the up or down key, the form is blurred (unfocused).

http://platform.dandigbib.org/issues/1267
